### PR TITLE
Enable configuring port

### DIFF
--- a/lifx-lan.cabal
+++ b/lifx-lan.cabal
@@ -34,6 +34,7 @@ library
         colour ^>= 2.3.6,
         composition ^>= 1.0.2.1,
         containers ^>= {0.6.2.1, 0.7},
+        exceptions ^>= {0.10},
         extra ^>= {1.7.1, 1.8},
         monad-loops ^>= 0.4.3,
         mtl ^>= {2.2.2, 2.3},

--- a/src/Lifx/Lan.hs
+++ b/src/Lifx/Lan.hs
@@ -59,6 +59,7 @@ module Lifx.Lan (
 
 import Control.Concurrent
 import Control.Monad
+import Control.Monad.Catch
 import Control.Monad.Except
 import Control.Monad.Extra
 import Control.Monad.Reader
@@ -385,22 +386,29 @@ runLifx m =
         Right x -> pure x
 
 runLifxT ::
-    (MonadIO m) =>
+    (MonadIO m, MonadMask m) =>
     -- | Timeout for waiting for message responses, in microseconds.
     Int ->
     LifxT m a ->
     m (Either LifxError a)
-runLifxT timeoutDuration (LifxT x) = do
-    sock <- liftIO $ socket AF_INET Datagram defaultProtocol
-    liftIO $ setSocketOption sock Broadcast 1
-    liftIO . bind sock $ SockAddrInet defaultPort 0
-    source <-
-        untilJustM $
-            randomIO <&> \case
-                -- 0 and 1 cause problems on old firmware: https://lan.developer.lifx.com/docs/packet-contents#frame-header
-                n | n > 1 -> Just n
-                _ -> Nothing
-    runExceptT $ runReaderT (evalStateT x 0) (sock, source, timeoutDuration)
+runLifxT timeoutDuration (LifxT x) =
+    bracket
+        ( liftIO do
+            sock <- socket AF_INET Datagram defaultProtocol
+            setSocketOption sock Broadcast 1
+            bind sock $ SockAddrInet defaultPort 0
+            pure sock
+        )
+        (liftIO . close)
+        \sock -> do
+            source <-
+                liftIO
+                    . untilJustM
+                    $ randomIO <&> \case
+                        -- 0 and 1 cause problems on old firmware: https://lan.developer.lifx.com/docs/packet-contents#frame-header
+                        n | n > 1 -> Just n
+                        _ -> Nothing
+            runExceptT $ runReaderT (evalStateT x 0) (sock, source, timeoutDuration)
 
 class (Monad m) => MonadLifx m where
     -- | The type of errors associated with 'm'.


### PR DESCRIPTION
I'm using this on some of my devices (a NixOS Raspberry Pi and an EndeavourOS desktop), since broadcasting (and thus e.g. device discovery) only seems to be guaranteed to work on open ports, so I have to manually assign one of the ports I've opened.

I want to suss out some of the details though before I merge this. In particular, it's not clear why _sends_ (as opposed to broadcasts) are working at all without setting the port to an open one. And it even seems that broadcasts work when preceded by a send on the same port.